### PR TITLE
Default testalert to never

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Version 1.1.3 (2022-09-24)
+# Version 1.1.3 (2022-09-25)
 
 ## Added
 
@@ -9,6 +9,7 @@
 * Service had insufficient priviliges for SQLite
 * Logging bug
 * Excessive reporting on empty alerts from KatSys
+* Default alert silent time to never
 
 ## Removed
 

--- a/src/model/zvei.mjs
+++ b/src/model/zvei.mjs
@@ -7,11 +7,11 @@ export default class ZVEI {
      * 
      * @param {string|number} zvei_id 
      * @param {string} [description = ""]
-     * @param {number} [test_day = 0]
+     * @param {number} [test_day = -1]
      * @param {string} [test_time_start = "00:00"]
      * @param {string} [test_time_end = "00:00"]
      */
-    constructor(zvei_id, description = "", test_day = 0, test_time_start = "00:00", test_time_end = "00:00") {
+    constructor(zvei_id, description = "", test_day = -1, test_time_start = "00:00", test_time_end = "00:00") {
         
         const validated_id = ZVEI.validate_zvei_id(zvei_id)
         if (!validated_id.isPresent()) {
@@ -24,7 +24,7 @@ export default class ZVEI {
         }
         this.description = description;
 
-        if (test_day < 0 || test_day >= 7) {
+        if (test_day < -1 || test_day >= 7) {
             throw new Error(`Test day '${test_day}' is not from the range [0,6]`);
         }
         this.test_day = test_day;

--- a/src/model/zvei.mjs
+++ b/src/model/zvei.mjs
@@ -25,7 +25,7 @@ export default class ZVEI {
         this.description = description;
 
         if (test_day < -1 || test_day >= 7) {
-            throw new Error(`Test day '${test_day}' is not from the range [0,6]`);
+            throw new Error(`Test day '${test_day}' is not from the range [-1,6]`);
         }
         this.test_day = test_day;
 

--- a/test/model/zvei.test.mjs
+++ b/test/model/zvei.test.mjs
@@ -61,7 +61,7 @@ describe("ZVEI creation", () => {
         {
             id: 201,
             desc: "JEST TeST ZVEI agaiN",
-            day: -1,
+            day: -2,
             start: "02:00",
             end: "03:02"
         },

--- a/test/server.test.mjs
+++ b/test/server.test.mjs
@@ -70,7 +70,7 @@ describe("server operation", () => {
         
         let result = await server.queue_alarm(zvei, timestamp, information_content);
 
-        const zvei_obj = new ZVEI(zvei, "", 0, "00:00", "00:00");
+        const zvei_obj = new ZVEI(zvei);
         expect(spyMessaging).toHaveBeenCalledWith([], timestamp, config.alert_time_zone, zvei_obj);
         expect(result).toBeTruthy();
 


### PR DESCRIPTION
Currently all alerts set to default values are taken as testalerts on a Sunday. This PR fixes the issue and defaults to no testalert.