### PR TITLE
Fix heartbeat probe

### DIFF
--- a/src/db.mjs
+++ b/src/db.mjs
@@ -661,7 +661,7 @@ export class database {
 
 
     /**
-     * Gets the list of alarm subscriptions for FCM.
+     * Gets the list of alarm subscriptions for Telegram check.
      * @returns {Promise<Array<{user_id: number, group_id: number, chat_id: string, token: string}>>} An array of alert subscriptions [[user_id, group_id, chat_id]].
      */
     async get_check_users_list() {
@@ -672,10 +672,25 @@ export class database {
         FROM Groups
         JOIN UserGroups ON Groups.group_id = UserGroups.group_id
         JOIN Users ON UserGroups.user_id = Users.user_id
-    `;
+        `;
 
         let rows = await this.#sql_query(sql, []);
         return rows;
+    }
+
+    /**
+     * Gets the list of alarm subscriptions for FCM.
+     * @returns {Promise<Array<{user_id: number, token: string}>>} An array of alert subscriptions [[user_id, group_id, chat_id]].
+     */
+    async get_check_fcm_users_list() {
+
+            let sql = `
+            SELECT Users.user_id, Users.token
+            FROM Users
+            `;
+    
+            let rows = await this.#sql_query(sql, []);
+            return rows;
     }
 
     /**

--- a/src/messaging.mjs
+++ b/src/messaging.mjs
@@ -142,6 +142,13 @@ async function sendFcmMessages(fcmMessage, user_ids) {
               
               let user = new User(user_id, "", "");
               db.remove_user(user);
+            }else if(jsonResponse.error.code == 400 && jsonResponse.error.status == "INVALID_ARGUMENT"){
+              //This seems to occur for obsolete tokens
+              const user_id = user_ids[msg];
+              log.debug("FCM responded invalid (token) argument. Removing user.");
+              
+              let user = new User(user_id, "", "");
+              db.remove_user(user);
             } else {
               log.error("Error sending FCM message: " + data);
             }

--- a/src/messaging.mjs
+++ b/src/messaging.mjs
@@ -139,14 +139,14 @@ async function sendFcmMessages(fcmMessage, user_ids) {
               //Device ID does not exist (any more) - delete it.
               const user_id = user_ids[msg];
               log.debug("FCM responded entity not found. Removing user.");
-              
+
               let user = new User(user_id, "", "");
               db.remove_user(user);
-            }else if(jsonResponse.error.code == 400 && jsonResponse.error.status == "INVALID_ARGUMENT"){
+            } else if (jsonResponse.error.code == 400 && jsonResponse.error.status == "INVALID_ARGUMENT") {
               //This seems to occur for obsolete tokens
               const user_id = user_ids[msg];
               log.debug("FCM responded invalid (token) argument. Removing user.");
-              
+
               let user = new User(user_id, "", "");
               db.remove_user(user);
             } else {

--- a/src/server.js
+++ b/src/server.js
@@ -209,7 +209,7 @@ function setup_cleaner(timezone, hour = 0) {
     telegram_bot.remove_invalid_user_subscriptions();
 
     //Check and remove all invalid FCM device IDs
-    const check_list = await db.get_check_users_list();
+    const check_list = await db.get_check_fcm_users_list();
     await messaging.heartbeatProbe(check_list);
 
   });


### PR DESCRIPTION
This fixes #65 

Changes
- handle 400 "INVALID_ARGUMENT" response from FCM
- adjust heartbeat query to avoid duplicate heartbeat probes